### PR TITLE
Updates to initialize.js

### DIFF
--- a/initialize.js
+++ b/initialize.js
@@ -68,7 +68,9 @@ function bind_all() {
 
 function importContract(contract) {
   const filenameNoExt = filenameNoExtension(contract);
-  const outputPath = `${dirname}/src/contracts/${filenameNoExt}.ts`;
+  const outputDir = `${dirname}/src/contracts/`;
+  mkdirSync(outputDir, { recursive: true })
+
   const importContent = `import * as Client from '${filenameNoExt}';\n` +
                         `import { rpcUrl } from './util';\n\n` +
                         `export default new Client.Contract({\n` +
@@ -76,6 +78,7 @@ function importContract(contract) {
                         `  rpcUrl,\n` +
                         `});\n`;
   
+  const outputPath = `${outputDir}/${filenameNoExt}.ts`;
   writeFileSync(outputPath, importContent);
   console.log(`Created import for ${filenameNoExt}`);
 }

--- a/initialize.js
+++ b/initialize.js
@@ -25,8 +25,8 @@ function fund_all() {
 }
 
 function build_all() {
-  exe(`rm ${dirname}/target/wasm32-unknown-unknown/release/*.wasm`);
-  exe(`rm ${dirname}/target/wasm32-unknown-unknown/release/*.d`);
+  exe(`rm -f ${dirname}/target/wasm32-unknown-unknown/release/*.wasm`);
+  exe(`rm -f ${dirname}/target/wasm32-unknown-unknown/release/*.d`);
   exe(`${soroban} contract build`);
 }
 


### PR DESCRIPTION
I ran into a couple of things when I used this template for `soroban contract init`, and was able to get initialize.js working with the updates in this PR.

I also ran into a failure to find `./util` when actually running the astro process.
```
Error: Failed to load url ./util (resolved id: ./util) in /Users/elizabethengelman/Projects/Aha-Labs/here/src/contracts/soroban_hello_world_contract.ts. Does the file exist?
    at loadAndTransform (file:///Users/elizabethengelman/Projects/Aha-Labs/here/node_modules/vite/dist/node/chunks/dep-9A4-l-43.js:49731:21)
    at async instantiateModule (file:///Users/elizabethengelman/Projects/Aha-Labs/here/node_modules/vite/dist/node/chunks/dep-9A4-l-43.js:50759:10)
```