### PR TITLE
fix: include src/contracts/util.ts in `main`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
-SOROBAN_NETWORK_PASSPHRASE="Standalone Network ; February 2017"
-SOROBAN_RPC_URL="http://localhost:8000/soroban/rpc"
+# Prefix with "PUBLIC_" to make available in Astro frontend files
+PUBLIC_SOROBAN_NETWORK_PASSPHRASE="Standalone Network ; February 2017"
+PUBLIC_SOROBAN_RPC_URL="http://localhost:8000/soroban/rpc"
+
 SOROBAN_ACCOUNT="me"

--- a/initialize.js
+++ b/initialize.js
@@ -4,6 +4,14 @@ import { execSync } from 'child_process';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
+// Load environment variables starting with PUBLIC_ into the environment,
+// so we don't need to specify duplicate variables in .env
+for (const key in process.env) {
+  if (key.startsWith('PUBLIC_')) {
+    process.env[key.substring(7)] = process.env[key];
+  }
+}
+
 console.log("###################### Initializing ########################");
 
 // Get dirname (equivalent to the Bash version)
@@ -94,8 +102,6 @@ function import_all() {
     }
   });
 }
-
-exe('echo $SOROBAN_ACCOUNT $SOROBAN_NETWORK_PASSPHRASE $SOROBAN_RPC_URL');
 
 // Calling the functions (equivalent to the last part of your bash script)
 fund_all();

--- a/publish.sh
+++ b/publish.sh
@@ -13,10 +13,12 @@ mkdir -p dist
 
 # Copy desired files into `dist`
 rsync -av --progress .vscode .env.example .gitattributes .gitignore * \
-  --exclude="dist" \
-  --exclude="contracts" \
+  --exclude="/contracts" \
+  --exclude="/src/contracts/[!util]*" \
   --exclude="LICENSE" \
-  --exclude="publish.sh" \
+  --exclude="dist" \
   --exclude="node_modules" \
+  --exclude="packages/*/" \
+  --exclude="publish.sh" \
   --exclude="target" \
   dist

--- a/src/contracts/util.ts
+++ b/src/contracts/util.ts
@@ -1,2 +1,2 @@
-export const rpcUrl = import.meta.env.SOROBAN_RPC_URL ?? "http://localhost:8000/";
-export const networkPassphrase = import.meta.env.SOROBAN_NETWORK_PASSPHRASE ?? "Standalone Network ; February 2017";
+export const rpcUrl = import.meta.env.PUBLIC_SOROBAN_RPC_URL ?? "http://localhost:8000/"
+export const networkPassphrase = import.meta.env.PUBLIC_SOROBAN_NETWORK_PASSPHRASE ?? "Standalone Network ; February 2017"


### PR DESCRIPTION
This wasn't being included because of too-aggressive rsync `exclude` options.