### PR TITLE
Fix the import content to work with the new SDK contract client

### DIFF
--- a/initialize.js
+++ b/initialize.js
@@ -61,7 +61,7 @@ function deploy_all() {
   mkdirSync(contractsDir, { recursive: true });
 
   const wasmFiles = readdirSync(`${dirname}/target/wasm32-unknown-unknown/release`).filter(file => file.endsWith('.wasm'));
-  
+
   wasmFiles.forEach(wasmFile => {
     deploy(`${dirname}/target/wasm32-unknown-unknown/release/${wasmFile}`);
   });
@@ -96,7 +96,7 @@ function importContract(contract) {
     `  ...Client.networks.${process.env.SOROBAN_NETWORK},\n` +
     `  rpcUrl,\n` +
     `${process.env.SOROBAN_NETWORK === 'local' || 'standalone' ? `  allowHttp: true,\n` : null}` +
-    `  publicKey: ${GENESIS_ACCOUNTS[process.env.SOROBAN_NETWORK]},\n` +
+    `  publicKey: '${GENESIS_ACCOUNTS[process.env.SOROBAN_NETWORK]}',\n` +
     `});\n`;
 
   const outputPath = `${outputDir}/${filenameNoExt}.ts`;

--- a/initialize.js
+++ b/initialize.js
@@ -12,6 +12,16 @@ for (const key in process.env) {
   }
 }
 
+// The stellar-sdk Client requires (for now) a defined public key. These are
+// the Genesis accounts for each of the "typical" networks, and should work as
+// a valid, funded network account.
+const GENESIS_ACCOUNTS = {
+  public: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7',
+  testnet: 'GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H',
+  futurenet: 'GADNDFP7HM3KFVHOQBBJDBGRONMKQVUYKXI6OYNDMS2ZIK7L6HA3F2RF',
+  standalone: 'GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPV6LY4UV2GL6VJGIQRXFDNMADI',
+}
+
 console.log("###################### Initializing ########################");
 
 // Get dirname (equivalent to the Bash version)
@@ -82,9 +92,11 @@ function importContract(contract) {
   const importContent =
     `import * as Client from '${filenameNoExt}';\n` +
     `import { rpcUrl } from './util';\n\n` +
-    `export default new Client.Contract({\n` +
+    `export default new Client.Client({\n` +
     `  ...Client.networks.${process.env.SOROBAN_NETWORK},\n` +
     `  rpcUrl,\n` +
+    `${process.env.SOROBAN_NETWORK === 'local' || 'standalone' ? `  allowHttp: true,\n` : null}` +
+    `  publicKey: ${GENESIS_ACCOUNTS[process.env.SOROBAN_NETWORK]},\n` +
     `});\n`;
 
   const outputPath = `${outputDir}/${filenameNoExt}.ts`;

--- a/src/contracts/util.ts
+++ b/src/contracts/util.ts
@@ -1,2 +1,2 @@
-export const rpcUrl = import.meta.env.PUBLIC_SOROBAN_RPC_URL ?? "http://localhost:8000/"
+export const rpcUrl = import.meta.env.PUBLIC_SOROBAN_RPC_URL ?? "http://localhost:8000/soroban/rpc"
 export const networkPassphrase = import.meta.env.PUBLIC_SOROBAN_NETWORK_PASSPHRASE ?? "Standalone Network ; February 2017"


### PR DESCRIPTION
Spent some time troubleshooting this, and I think this'll work well to get the template bindings to work with the Stellar SDK's `contract_client` stuff.